### PR TITLE
Add check for empty phrases

### DIFF
--- a/dist/src/controller.js
+++ b/dist/src/controller.js
@@ -52,7 +52,7 @@ var TranslationController = (function () {
                 return 'ctx:' + descriptor.msgctxt + ';' + 'plural:' + descriptor.msgidPlural + ';' + descriptor.msgid;
         }
     };
-    // Make key to fill disctionary with translations. 
+    // Make key to fill disctionary with translations.
     // This should be fully compatible with getDictKeyForDescriptor!
     TranslationController.prototype.getDictKeyForEntry = function (item) {
         switch (item.type) {
@@ -119,6 +119,11 @@ var TranslationController = (function () {
         var dict = {};
         for (var _i = 0, items_1 = items; _i < items_1.length; _i++) {
             var item = items_1[_i];
+            // Don't add item in dict if no translation provided
+            if ((item.type === 'single' && !item.translation) ||
+                (item.type === 'plural' && !item.translations.every(function (i) { return !!i; }))) {
+                continue;
+            }
             var key = this.getDictKeyForEntry(item);
             if (!key) {
                 continue;

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -64,7 +64,7 @@ export class TranslationController {
   }
 
 
-  // Make key to fill disctionary with translations. 
+  // Make key to fill disctionary with translations.
   // This should be fully compatible with getDictKeyForDescriptor!
   protected getDictKeyForEntry(item: I18NEntry): string | undefined {
     switch (item.type) {
@@ -138,6 +138,13 @@ export class TranslationController {
   protected makeNewDict(items: I18NEntry[]): { [key: string]: string[] } {
     let dict: { [key: string]: string[] } = {};
     for (let item of items) {
+      // Don't add item in dict if no translation provided
+      if ((item.type === 'single' && !item.translation) ||
+        (item.type === 'plural' && !item.translations.every((i) => !!i))
+      ) {
+        continue;
+      }
+
       let key = this.getDictKeyForEntry(item);
       if (!key) {
         continue;

--- a/tests/controller.ts
+++ b/tests/controller.ts
@@ -323,6 +323,15 @@ describe('I18n end-user library', () => {
       context: 'ctx2',
       entry: ['test4-1', 'test4-2'],
       translations: ['trans4-1', 'trans4-2', 'trans4-3'] // different forms count!
+    }, {
+      type: 'single', // no transaltion provided
+      entry: 'test2',
+      context: 'ctx3'
+    }, {
+      type: 'plural',
+      context: 'ctx4',
+      entry: ['test5-1', 'test5-2'],
+      translations: ['', '', 'trans5-3'] // not all translations provided
     }];
 
     assert.deepEqual(t.pMakeNewDict(items), {


### PR DESCRIPTION
Don't add item in dict if any translation no provided. Instead return fallback for this case.